### PR TITLE
Update to version 4.0

### DIFF
--- a/altap-salamander/altap-salamander.nuspec
+++ b/altap-salamander/altap-salamander.nuspec
@@ -5,7 +5,7 @@
     <!-- Read this before publishing packages to chocolatey.org: https://github.com/chocolatey/chocolatey/wiki/CreatePackages -->
     <id>altap-salamander</id>
     <title>Altap Salamander</title>
-    <version>3.0.8</version>
+    <version>4.0.0</version>
     <authors>ALTAP spol. s r.o.</authors>
     <owners>Oliver Kötter</owners>
     <summary>Altap Salamander</summary>
@@ -22,7 +22,7 @@
     <mailingListUrl></mailingListUrl>
     <bugTrackerUrl></bugTrackerUrl>-->
     <tags>altap-salamander admin</tags>
-    <copyright>Copyright © 1999-2017 ALTAP. All rights reserved.</copyright>
+    <copyright>Copyright © 1999-2020 ALTAP. All rights reserved.</copyright>
     <licenseUrl>http://www.altap.cz/salamander/eula/</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://pics.computerbase.de/1/4/0/8/8/logo-256.png</iconUrl>

--- a/altap-salamander/tools/chocolateyInstall.ps1
+++ b/altap-salamander/tools/chocolateyInstall.ps1
@@ -1,8 +1,8 @@
 $ErrorActionPreference = 'Stop'; # stop on all errors
 $packageName= 'altap-salamander' # arbitrary name for the package, used in messages
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url        = 'https://www.altap.cz/ftp/salamand/as308x86.exe' # download url
-$url64      = 'https://www.altap.cz/ftp/salamand/as308x64.exe' # 64bit URL here or remove - if installer is both, use $url
+$url        = 'https://www.altap.cz/ftp/salamand/as40x86.exe' # download url
+$url64      = 'https://www.altap.cz/ftp/salamand/as40x64.exe' # 64bit URL here or remove - if installer is both, use $url
 $packageArgs = @{
   packageName   = $packageName
   unzipLocation = $toolsDir
@@ -12,9 +12,9 @@ $packageArgs = @{
   silentArgs = '/x /s'
   validExitCodes = @(0)
   softwareName  = 'altap-salamander*' #part or all of the Display Name as you see it in Programs and Features. It should be enough to be unique
-  checksum      = '59FB36FDBACCBA9ECC0C58832B05ACD646F98CB5EE423CD748391C2FDAF4063012D9141EAED83F2E2DED2AF24029AE46C3E90186418B05D483617966A8842919'
+  checksum      = '3B4E16790DA5D5F979EA9F3D3C7EC5EFAFCAD284A5342F88B89B2A004B6F2FD7AE44899E1CE78D90B9005E345B347E230D875520C681AA5AAA960C12A0097B5D'
   checksumType  = 'sha512' #default is md5, can also be sha1
-  checksum64    = '803B69FB4C3B1E3199A858BCD986D9A673F89493B30818FD4A221DCE2137A26521302C7CBEB26D66DF0946A4333D62AE38A8BA7C8976E94DDDC5A20BA9803C5D'
+  checksum64    = 'D119F06E29DE6CA082A2688588729A69B0D141E6B55268466CCD476684C52F8E7E2E381C5459196C1C4F7B59A188CC92395658D9C7E11B64ECAC73389E6ACBF3'
   checksumType64= 'sha512' #default is checksumType
 }
 


### PR DESCRIPTION
Updated to download 4.0 and adjusted SHA512 hashes.
Remove.exe is still present in version 4.0.